### PR TITLE
Router query string support

### DIFF
--- a/lib/router/sequential.js
+++ b/lib/router/sequential.js
@@ -15,15 +15,27 @@ module.exports = (config = {}) => {
   const router = new Trouter()
   router.id = config.id
 
-  router.lookup = (req, res, step) => {
-    if (req.originalUrl === undefined) {
-      req.originalUrl = req.originalUrl || req.url
-    }
+  router._use = router.use
 
-    const reqCacheKey = `${req.method + req.url}`
+  router.use = (prefix, ...middlewares) => {
+    if (typeof prefix === 'function') {
+      middlewares = prefix
+      prefix = '/'
+    }
+    router._use(prefix, middlewares)
+
+    return this
+  }
+
+  router.lookup = (req, res, step) => {
+    req.url = req.url || '/'
+    req.originalUrl = req.originalUrl || req.url
+    req.path = req.url.split('?')[0]
+
+    const reqCacheKey = `${req.method + req.path}`
     let match = cache.get(reqCacheKey)
     if (!match) {
-      match = router.find(req.method, req.url)
+      match = router.find(req.method, req.path)
       cache.set(reqCacheKey, match)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "0http",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "0http",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Cero friction HTTP request router. The need for speed!",
   "main": "index.js",
   "scripts": {
@@ -18,6 +18,9 @@
     "router",
     "rest"
   ],
+  "engines": {
+    "node": ">=10.x"
+  },
   "author": "Rolando Santamaria Maso <kyberneees@gmail.com>",
   "license": "MIT",
   "bugs": {

--- a/tests/nested-routers.test.js
+++ b/tests/nested-routers.test.js
@@ -6,7 +6,6 @@ describe('0http Web Framework - Nested Routers', () => {
   const baseUrl = 'http://localhost:' + process.env.PORT
 
   const { router, server } = require('../index')({
-    server: require('../lib/server/low')(),
     router: require('../lib/router/sequential')()
   })
 
@@ -31,10 +30,8 @@ describe('0http Web Framework - Nested Routers', () => {
       next()
     })
 
-    server.start(~~process.env.PORT, serverSocket => {
-      if (serverSocket) {
-        done()
-      }
+    server.listen(~~process.env.PORT, err => {
+      if (!err) done()
     })
   })
 
@@ -56,10 +53,10 @@ describe('0http Web Framework - Nested Routers', () => {
       })
 
     await request(baseUrl)
-      .get('/r2/url')
+      .get('/r2/url?var=value')
       .expect(200)
       .then((response) => {
-        expect(response.text).to.equal('/r2/url:/url')
+        expect(response.text).to.equal('/r2/url?var=value:/url?var=value')
       })
   })
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -11,6 +11,9 @@ describe('0http Web Framework - Smoke', () => {
   })
 
   it('should successfully register service routes', (done) => {
+    router.use((req, res, next) => next())
+    router.use('/', (req, res, next) => next())
+
     router.get('/pets/:id', function (req, res) {
       res.setHeader('content-type', 'application/json')
       res.end(JSON.stringify({
@@ -66,7 +69,7 @@ describe('0http Web Framework - Smoke', () => {
 
   it('should GET JSON response /pets/:id', async () => {
     await request(baseUrl)
-      .get('/pets/0')
+      .get('/pets/0?var=value')
       .expect(200)
       .then((response) => {
         expect(response.body.name).to.equal('Happy Cat')


### PR DESCRIPTION
- Ignoring query strings during requests matching
- Make prefix optional when registering global middlewares