### PR TITLE
Better instanceof check

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ server.listen(3000)
   ```
 - **cacheSize**: Router matching LRU cache size. A given value <= 0 will disable the cache. Default value: `1000`
 - **errorHandler**: Global error handler function. Default value: 
+  
   ```js 
   (err, req, res) => {
     res.statusCode = 500
@@ -81,7 +82,10 @@ server.listen(3000)
   }
   ```
 
+* **prioRequestsProcessing**: `true` to use SetImmediate to prioritize router lookup, `false` to disable. By default `true`, if used with native Node.js `http` and `https` servers. Set to `false`, if using Node.js Native Addon server, such as uWebSockets.js, as this will cause a huge performance penalty
+
 Example passing configuration options:
+
 ```js
 const sequential = require('0http/lib/router/sequential')
 const { router, server } = cero({
@@ -180,6 +184,7 @@ wrk -t8 -c40 -d5s http://127.0.0.1:3000/hi
   `Requests/sec:  82682.86`
 
 > For more accurate benchmarks please see:
+>
 > - https://github.com/the-benchmarker/web-frameworks
 
 ## Support / Donate 💚

--- a/index.js
+++ b/index.js
@@ -1,14 +1,30 @@
 const http = require('http')
+const httpServer = http.Server
+const httpsServer = require('https').Server
 
 module.exports = (config = {}) => {
   const router = config.router || require('./lib/router/sequential')()
   const server = config.server || http.createServer()
 
-  server.on('request', (req, res) => {
-    server instanceof http.Server
-      ? setImmediate(() => router.lookup(req, res))
-      : router.lookup(req, res)
-  })
+  config.prioRequestsProcessing = config.prioRequestsProcessing || server instanceof httpServer || server instanceof httpsServer
+  
+  /* 
+  Native server can also be https server, so we also need to check for it.
+  Unfortunately, there appears to be no proper way to check for http2 server.
+  */
+  
+
+  if (config.prioRequestsProcessing) {
+    server.on('request', (req, res) => {
+      setImmediate(() => router.lookup(req, res))
+    })
+  }
+  else {
+    server.on('request', (req, res) => {
+      router.lookup(req, res)
+    })
+  }
+  
 
   return {
     router,

--- a/index.js
+++ b/index.js
@@ -7,24 +7,21 @@ module.exports = (config = {}) => {
   const server = config.server || http.createServer()
 
   config.prioRequestsProcessing = config.prioRequestsProcessing || server instanceof httpServer || server instanceof httpsServer
-  
-  /* 
+
+  /*
   Native server can also be https server, so we also need to check for it.
   Unfortunately, there appears to be no proper way to check for http2 server.
   */
-  
 
   if (config.prioRequestsProcessing) {
     server.on('request', (req, res) => {
       setImmediate(() => router.lookup(req, res))
     })
-  }
-  else {
+  } else {
     server.on('request', (req, res) => {
       router.lookup(req, res)
     })
   }
-  
 
   return {
     router,


### PR DESCRIPTION
This PR introduces better check on whether `setImmediate` can be used, which accounts for the possibility that 0http might be used with `https` server. Additionally, the check is now only done at initial load time, avoding the need to do the check at every HTTP request. Unfortunately, I am not aware of a proper way to check for node `http2` server, so I've introduced `config.prioRequestsProcessing` option instead (same naming as in Restana). Not sure, if theses changes should be considered Minor or Patch version bump